### PR TITLE
Avoid transparency on old android Devices

### DIFF
--- a/src/android/change_password_dialog.xml
+++ b/src/android/change_password_dialog.xml
@@ -13,6 +13,7 @@
         android:ems="10"
         android:hint="Current Password"
         android:imeOptions="actionNext|flagNoExtractUi"
+        android:textColor="#ff000000"
         android:inputType="textPassword" >
         <requestFocus />
     </EditText>
@@ -24,6 +25,7 @@
         android:ems="10"
         android:hint="New Password"
         android:imeOptions="actionNext|flagNoExtractUi"
+        android:textColor="#ff000000"
         android:inputType="textPassword" />
     <EditText
         android:id="@+id/ConfirmPassword"
@@ -33,5 +35,6 @@
         android:ems="10"
         android:hint="Confirm New Password"
         android:imeOptions="actionDone|flagNoExtractUi"
+        android:textColor="#ff000000"
         android:inputType="textPassword" />
 </LinearLayout>

--- a/src/android/confirm_password_dialog.xml
+++ b/src/android/confirm_password_dialog.xml
@@ -13,6 +13,7 @@
         android:ems="10"
         android:hint="Password"
         android:imeOptions="actionNext|flagNoExtractUi"
+        android:textColor="#ff000000"
         android:inputType="textPassword" >
         <requestFocus />
     </EditText>
@@ -24,5 +25,6 @@
         android:ems="10"
         android:hint="Confirm Password"
         android:imeOptions="actionDone|flagNoExtractUi"
+        android:textColor="#ff000000"
         android:inputType="textPassword" />
 </LinearLayout>


### PR DESCRIPTION
Solving the issue I posted ([Issue 1](https://github.com/Justin-Credible/cordova-plugin-password-dialog/issues/1))